### PR TITLE
chore: 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ts-blank-space",
-    "version": "0.3.3333",
+    "version": "0.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ts-blank-space",
-            "version": "0.3.3333",
+            "version": "0.4.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "typescript": "5.1.6 - 5.6.x"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
     "name": "ts-blank-space",
     "description": "A small, fast, pure JavaScript, type-stripper using the official TypeScript parser",
-    "version": "0.3.3333",
+    "version": "0.4.0",
     "license": "Apache-2.0",
+    "homepage": "https://bloomberg.github.io/ts-blank-space",
     "contributors": [
         "Ashley Claymore <aclaymore@bloomberg.net>",
         "Kubilay Kahveci <mkahveci@bloomberg.net>",


### PR DESCRIPTION
Bump version to `0.4.0`, also adds `homepage` to the `package.json`.