### PR TITLE
fix: loader works on node 18.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ console.log(blankSourceFile(ast));
 # Install (one time):
 $ npm install --save-dev ts-blank-space
 
-# Example usage (Node.js v18.18):
+# Example usage (Node.js >= v18.20):
 $ node --import ts-blank-space/register ./path/to/your/file.ts
 ```
 

--- a/loader/register.js
+++ b/loader/register.js
@@ -1,4 +1,3 @@
 import { register } from "node:module";
-import { pathToFileURL } from "node:url";
 
-register("./hooks.js", pathToFileURL(import.meta.filename));
+register("./hooks.js", import.meta.url);


### PR DESCRIPTION
Node 18 does not support `import.meta.filename` this PR fixes this to use `import.meta.url`. Still needs node 18.20, rather than `18.18` for the `register` hook to be available.