### PR TITLE
docs: add ts-blank-loader reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,9 @@ TypeScript may add an `export {};` if all `import`s and `export`s were removed (
 
 Because `ts-blank-space` only removes code, this is not performed. To force the output to always have an ESM syntactic marker, you can manually append `"export {};"`;
 
-## Looking into a bundler integration?
+## 3rd party ecosystem plugins
 
-There is currently a third-party module providing integration with Webpack & Rspack - Find more about [ts-blank-loader](https://github.com/leimonio/ts-blank-loader)
+- Webpack/Rspack: [ts-blank-loader](https://github.com/leimonio/ts-blank-loader)
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ TypeScript may add an `export {};` if all `import`s and `export`s were removed (
 
 Because `ts-blank-space` only removes code, this is not performed. To force the output to always have an ESM syntactic marker, you can manually append `"export {};"`;
 
+## Looking into a bundler integration?
+There is currently a third-party module providing integration with Webpack & Rspack - Find more about [ts-blank-loader](https://github.com/leimonio/ts-blank-loader)
+
 ## Contributions
 
 We :heart: contributions.

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ TypeScript may add an `export {};` if all `import`s and `export`s were removed (
 Because `ts-blank-space` only removes code, this is not performed. To force the output to always have an ESM syntactic marker, you can manually append `"export {};"`;
 
 ## Looking into a bundler integration?
+
 There is currently a third-party module providing integration with Webpack & Rspack - Find more about [ts-blank-loader](https://github.com/leimonio/ts-blank-loader)
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Because `ts-blank-space` only removes code, this is not performed. To force the 
 
 ## 3rd party ecosystem plugins
 
-- Webpack/Rspack: [ts-blank-loader](https://github.com/leimonio/ts-blank-loader)
+-   Webpack/Rspack: [ts-blank-loader](https://github.com/leimonio/ts-blank-loader)
 
 ## Contributions
 


### PR DESCRIPTION
**Describe your changes**
I'd like to raise awareness of using this module for typescript compilation with bundlers like webpack & rspack. I've released the first versions of the module and it's available on npm.

**Testing performed**
N/A

**Additional context**
N/A
