### PR TITLE
chore: eleventy@3 released

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
         "typescript": "^5.5.4"
     },
     "devDependencies": {
-        "@11ty/eleventy": "3.0.0-beta.1",
+        "@11ty/eleventy": "3.0.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
         "esbuild": "^0.23.0",
         "gh-pages": "^6.1.1",


### PR DESCRIPTION
**Describe your changes**
11ty 3.0.0 shipped: https://www.11ty.dev/blog/eleventy-v3/ so updating to use it instead of the beta.