### PR TITLE
Unsupported syntax for async arrow functions with multiline generic parameters

### DIFF
--- a/docs/unsupported_syntax.md
+++ b/docs/unsupported_syntax.md
@@ -188,3 +188,62 @@ Due to the following:
 -   `<const>val` can be re-written to `val as const`
 
 `ts-blank-space` has decided to not support the prefix style.
+
+### Async arrow functions with multiline generic parameters
+
+When using an `async` arrow function with generic parameters that span multiple lines, `ts-blank-space` may produce syntactically invalid JavaScript after removing the TypeScript syntax.
+
+Consider the following TypeScript code:
+
+```typescript
+// prettier-ignore
+const fn = async <
+    T,
+    U,
+    V
+>() => null;
+```
+
+After transformation with `ts-blank-space`, the output is:
+
+```javascript
+const fn = async
+
+
+
+ () => null;
+```
+
+This results in multiple empty lines and a syntactically invalid arrow function, leading to a runtime error:
+
+```
+Uncaught SyntaxError: Malformed arrow function parameter list
+```
+
+#### Workaround
+
+To avoid this issue, you can:
+
+-   Use a function declaration instead of a function expression:
+
+    ```typescript
+    // prettier-ignore
+    async function fn<
+        T,
+        U,
+        V
+    >() {
+        return null;
+    }
+    ```
+
+-   Keep the generic parameters on the same line:
+
+    ```typescript
+    // prettier-ignore
+    const fn = async <T, U, V>() => null;
+    ```
+
+-   Disable Prettier's automatic formatting for this section by adding `// prettier-ignore` comments.
+
+This issue occurs because the removal of the generic parameters leaves blank lines that interfere with the syntax of the `async` arrow function. By keeping the generic parameters on the same line or using a function declaration, you can avoid this problem.


### PR DESCRIPTION
First of all, thank you for your work on `ts-blank-space`. I've migrated all my projects to use it, and everything works great. It has been a breath of fresh air in the complex world of building TypeScript projects in monorepos.

I wanted to share an edge case I encountered. I understand that this is an edge case that can be resolved by suppressing Prettier or changing a method expression to a method declaration. I don't think this case can be fixed by changing anything in `ts-blank-space`.

I studied the [unsupported_syntax.md](./docs/unsupported_syntax.md) and didn't find this case documented. I believe it would be helpful to add it to the documentation.

**Problem Description:**

Consider the following async arrow function with generic parameters:

```typescript
const fn = async <T>() => null;
```

After transformation with `ts-blank-space`, I get:

```javascript
const fn = async () => null;
```

Which is syntactically correct.

However, if the function contains a large list of generic parameters, Prettier may move the parameters to new lines:

```typescript
const fn = async <
    T,
    U,
    V
>() => null;
```

After transformation with `ts-blank-space`, I get:

```javascript
const fn = async



 () => null;
```

This code is syntactically incorrect and leads to a runtime error:

```
Uncaught SyntaxError: Malformed arrow function parameter list
```

Since this is not an error in `ts-blank-space` but an example of code that is not supported by design, I think it would be helpful to add it to the documentation under unsupported syntax.