### PR TITLE
fix: handle async generic arrow functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The benefits of this library are:
     -   No [native-addons](https://nodejs.org/api/addons.html)
     -   No [child process](https://nodejs.org/api/child_process.html)
 -   It is small
-    -   Less than 700 lines of code and one dependency ([`TypeScript`](https://www.npmjs.com/package/typescript))
+    -   Around 700 lines of code and one dependency ([`TypeScript`](https://www.npmjs.com/package/typescript))
     -   By doing so little, the code should be relatively easy to maintain
 -   Delegates the parsing to the [official TypeScript parser](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API)
 -   No need for additional SourceMap processing; see ["where are my SourceMaps?"](#where-are-my-sourcemaps)
@@ -159,13 +159,11 @@ statementWithNoSemiColon
 ("not calling above statement");
 ```
 
-### Arrow function return types that introduce a new line
+### Arrow function type annotations that introduce a new line
 
-If the annotation marking the return type of an arrow function introduces a new line before the `=>`, then only replacing it with blank space would be incorrect.
+If the type annotations around an arrow function's parameters introduce a new line then only replacing them with blank space can be incorrect. Therefore, in addition to removing the type annotation, the `(` or `)` surrounding the function parameters may also be moved.
 
-Therefore, in addition to removing the type annotation, the `)` is moved down to the end of the type annotation.
-
-Example input:
+#### Example one - multi-line return type:
 
 <!-- prettier-ignore -->
 ```typescript
@@ -181,6 +179,24 @@ becomes:
 let f = (a        , b
 
 ) => [a, b];
+```
+
+#### Example two - `async` with multi-line type arguments:
+
+<!-- prettier-ignore -->
+```typescript
+let f = async <
+    T
+>(v: T) => {};
+```
+
+becomes:
+
+<!-- prettier-ignore -->
+```javascript
+let f = async (
+
+  v   ) => {};
 ```
 
 ## Unsupported Syntax

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-blank-space",
     "description": "A small, fast, pure JavaScript type-stripper that uses the official TypeScript parser.",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "license": "Apache-2.0",
     "homepage": "https://bloomberg.github.io/ts-blank-space",
     "contributors": [

--- a/src/blank-string.ts
+++ b/src/blank-string.ts
@@ -1,8 +1,9 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
 
-const FLAG_REPLACE_WITH_CLOSE_PAREN = 1;
-const FLAG_REPLACE_WITH_SEMI = 2;
+const FLAG_REPLACE_WITH_OPEN_PAREN = 1;
+const FLAG_REPLACE_WITH_CLOSE_PAREN = 2;
+const FLAG_REPLACE_WITH_SEMI = 3;
 
 function getSpace(input: string, start: number, end: number): string {
     let out = "";
@@ -29,6 +30,10 @@ export default class BlankString {
     constructor(input: string) {
         this.__input = input;
         this.__ranges = [];
+    }
+
+    blankButStartWithOpenParen(start: number, end: number): void {
+        this.__ranges.push(FLAG_REPLACE_WITH_OPEN_PAREN, start, end);
     }
 
     blankButEndWithCloseParen(start: number, end: number): void {
@@ -68,6 +73,9 @@ export default class BlankString {
                 rangeStart += 1;
             } else if (flags === FLAG_REPLACE_WITH_SEMI) {
                 out += ";";
+                rangeStart += 1;
+            } else if (flags === FLAG_REPLACE_WITH_OPEN_PAREN) {
+                out += "(";
                 rangeStart += 1;
             }
 

--- a/tests/fixture/cases/async-generic-arrow.ts
+++ b/tests/fixture/cases/async-generic-arrow.ts
@@ -1,0 +1,18 @@
+
+// Simple case
+const a = async<T>(v: T) => {};
+//             ^^^  ^^^
+
+// Hard case - generic spans multiple lines
+const b = async <
+    T
+>/**/(/**/v: T) => {};
+//   ^     ^^^
+
+// Harder case - generic and return type spans multiple lines
+const c = async <
+    T
+>(v: T): Promise<
+// ^^^ ^^^^^^^^^^
+    T
+> => v;

--- a/tests/fixture/output/async-generic-arrow.js
+++ b/tests/fixture/output/async-generic-arrow.js
@@ -1,0 +1,18 @@
+
+// Simple case
+const a = async   (v   ) => {};
+//             ^^^  ^^^
+
+// Hard case - generic spans multiple lines
+const b = async (
+     
+ /**/ /**/v   ) => {};
+//   ^     ^^^
+
+// Harder case - generic and return type spans multiple lines
+const c = async (
+     
+  v              
+                 
+     
+) => v;


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #19*

**Describe your changes**
This updates the transform to detect `async` arrow functions that have type parameters which span over multiple lines. When this is detected the `(` at the start of the functions parameters is moved to the start of the type parameters. Avoiding a new line character to appear directly after the `async` keyword.

**Testing performed**
A new fixture has been added that covers the issue being addresses.
