### PR TITLE
fix: avoid ASI hazard with computed class members

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ There are two cases, described here, where it does more than replace the TypeScr
 
 ### ASI (automatic semicolon insertion)
 
-To guard against [ASI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion) issues in the output, `ts-blank-space` will add `;` to the end of type-only statements.
+To guard against [ASI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion) issues in the output, `ts-blank-space` will add `;` to the end of type-only statements, and when removing a leading type annotation could introduce an ASI hazard.
 
-Example input:
+#### Example one - type-only statement
 
 <!-- prettier-ignore -->
 ```typescript
@@ -157,6 +157,26 @@ becomes:
 statementWithNoSemiColon
 ;
 ("not calling above statement");
+```
+
+#### Example two - computed class fields/methods
+
+<!-- prettier-ignore -->
+```typescript
+class C {
+    field = 1/* no ; */
+    public ["computed field not accessing above"] = 2
+}
+```
+
+becomes:
+
+<!-- prettier-ignore -->
+```javascript
+class C {
+    field = 1/* no ; */
+    ;      ["computed field not accessing above"] = 2
+}
 ```
 
 ### Arrow function type annotations that introduce a new line

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ts-blank-space",
-    "version": "0.4.1",
+    "version": "0.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ts-blank-space",
-            "version": "0.4.1",
+            "version": "0.4.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "typescript": "5.1.6 - 5.6.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-blank-space",
     "description": "A small, fast, pure JavaScript type-stripper that uses the official TypeScript parser.",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "license": "Apache-2.0",
     "homepage": "https://bloomberg.github.io/ts-blank-space",
     "contributors": [

--- a/tests/fixture/cases/asi.ts
+++ b/tests/fixture/cases/asi.ts
@@ -78,4 +78,16 @@ class ASI {
         ((() => { 1/*trailing*/})(), 1) + 1 as number/*trailing*/
         (1);
     }
+    g = 2/*missing ; */
+    public ["computed-field"] = 1
+//  ;^^^^^
+    h = 3/*missing ; */
+    public ["computed-method"]() {}
+//  ;^^^^^
+}
+
+class NoASI {
+    f = 1/*missing ; */
+    static readonly ["computed-field"] = 1
+//         ^^^^^^^^
 }

--- a/tests/fixture/output/asi.js
+++ b/tests/fixture/output/asi.js
@@ -78,4 +78,16 @@ class ASI {
         ((() => { 1/*trailing*/})(), 1) + 1;         /*trailing*/
         (1);
     }
+    g = 2/*missing ; */
+    ;      ["computed-field"] = 1
+//  ;^^^^^
+    h = 3/*missing ; */
+    ;      ["computed-method"]() {}
+//  ;^^^^^
+}
+
+class NoASI {
+    f = 1/*missing ; */
+    static          ["computed-field"] = 1
+//         ^^^^^^^^
 }


### PR DESCRIPTION
Fixes #21

**Describe your changes**
This change defends against a ASI hazard. When a computed class member name has a leading type modifier (`public/private/protected/readonly/override`) a `;` is inserted in it's place to avoid being interpreted as index lookup of the previous class member. For example:

```typescript
class C {
    f = 1
    public ["computed"] = 2
}
```

now becomes:

```typescript
class C {
    f = 1
    ;      ["computed"] = 2
}
```

**Testing performed**
New test fixtures have been added and all [ecosystem tests](https://github.com/bloomberg/ts-blank-space/tree/main/tests/ecosystem) were run. All tests passing.
