### PR TITLE
feat: allow TypeScript 5.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.4.3",
             "license": "Apache-2.0",
             "dependencies": {
-                "typescript": "5.1.6 - 5.6.x"
+                "typescript": "5.1.6 - 5.7.x || 5.7.1-rc"
             },
             "devDependencies": {
                 "@types/node": "^20.9.4",
@@ -54,10 +54,25 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/ts-blank-space-lkg/node_modules/typescript": {
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+            "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
         "node_modules/typescript": {
-            "version": "5.6.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-            "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+            "version": "5.7.1-rc",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.1-rc.tgz",
+            "integrity": "sha512-d6m+HT78uZtyUbXbUyIvuJ6kXCTSJEfy+2pZSUwt9d6JZ0kOMNDwhIILfV5FnaxMwVa48Yfw4sK0ISC4Qyq5tw==",
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "types": "./out/index.d.ts",
     "dependencies": {
-        "typescript": "5.1.6 - 5.6.x"
+        "typescript": "5.1.6 - 5.7.x || 5.7.1-rc"
     },
     "imports": {
         "#r": "ts-blank-space-lkg/register"


### PR DESCRIPTION
`ts-blank-space` is compatible with TypeScript 5.7 (based on testing with the RC).

This PR updates the `package.json` to reflect that 5.7 is an acceptable version of TypeScript to use as a dependency.