### PR TITLE
fix: more robust generic arrow handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ts-blank-space",
-    "version": "0.4.4",
+    "version": "0.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ts-blank-space",
-            "version": "0.4.4",
+            "version": "0.5.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "typescript": "5.1.6 - 5.7.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-blank-space",
     "description": "A small, fast, pure JavaScript type-stripper that uses the official TypeScript parser.",
-    "version": "0.4.4",
+    "version": "0.5.0",
     "license": "Apache-2.0",
     "homepage": "https://bloomberg.github.io/ts-blank-space",
     "contributors": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,14 +316,6 @@ function visitModifiers(modifiers: ArrayLike<ts.ModifierLike>, addSemi: boolean)
     }
 }
 
-function isAsync(modifiers: ArrayLike<ts.ModifierLike> | undefined): boolean {
-    if (!modifiers) return false;
-    for (let i = 0; i < modifiers.length; i++) {
-        if (modifiers[i].kind === SK.AsyncKeyword) return true;
-    }
-    return false;
-}
-
 /**
  * prop: T
  */
@@ -409,15 +401,15 @@ function visitFunctionLikeDeclaration(node: ts.FunctionLikeDeclaration, kind: ts
     }
 
     let moveOpenParen = false;
+    const params = node.parameters;
     if (node.typeParameters && node.typeParameters.length) {
-        moveOpenParen = isAsync(node.modifiers) && spansLines(node.typeParameters.pos, node.typeParameters.end);
+        moveOpenParen = spansLines(node.typeParameters.pos, params.pos);
         blankGenerics(node, node.typeParameters, moveOpenParen);
     }
 
     // method?
     node.questionToken && blankExact(node.questionToken);
 
-    const params = node.parameters;
     if (moveOpenParen) {
         str.blank(params.pos - 1, params.pos);
     }

--- a/tests/fixture/cases/arrow-functions.ts
+++ b/tests/fixture/cases/arrow-functions.ts
@@ -17,15 +17,22 @@ const c = async <
     T
 > => v;
 
+// https://github.com/bloomberg/ts-blank-space/issues/29
 (function () {
-    // https://github.com/bloomberg/ts-blank-space/issues/29
     return<T>
         (v: T) => v
-}());
+});
 (function () {
-    // https://github.com/bloomberg/ts-blank-space/issues/29
     return/**/<
         T
     >/**/(v: T)/**/:
     T/**/=> v
-}());
+});
+(function* () {
+    yield<T>
+(v: T)=>v;
+});
+(function* () {
+    throw<T>
+(v: T)=>v;
+});

--- a/tests/fixture/cases/arrow-functions.ts
+++ b/tests/fixture/cases/arrow-functions.ts
@@ -16,3 +16,16 @@ const c = async <
 // ^^^ ^^^^^^^^^^
     T
 > => v;
+
+(function () {
+    // https://github.com/bloomberg/ts-blank-space/issues/29
+    return<T>
+        (v: T) => v
+}());
+(function () {
+    // https://github.com/bloomberg/ts-blank-space/issues/29
+    return/**/<
+        T
+    >/**/(v: T)/**/:
+    T/**/=> v
+}());

--- a/tests/fixture/output/arrow-functions.js
+++ b/tests/fixture/output/arrow-functions.js
@@ -16,3 +16,16 @@ const c = async (
                  
      
 ) => v;
+
+(function () {
+    // https://github.com/bloomberg/ts-blank-space/issues/29
+    return(  
+         v   ) => v
+}());
+(function () {
+    // https://github.com/bloomberg/ts-blank-space/issues/29
+    return/**/(
+         
+     /**/ v         
+    )/**/=> v
+}());

--- a/tests/fixture/output/arrow-functions.js
+++ b/tests/fixture/output/arrow-functions.js
@@ -17,15 +17,22 @@ const c = async (
      
 ) => v;
 
+// https://github.com/bloomberg/ts-blank-space/issues/29
 (function () {
-    // https://github.com/bloomberg/ts-blank-space/issues/29
     return(  
          v   ) => v
-}());
+});
 (function () {
-    // https://github.com/bloomberg/ts-blank-space/issues/29
     return/**/(
          
      /**/ v         
     )/**/=> v
-}());
+});
+(function* () {
+    yield(  
+ v   )=>v;
+});
+(function* () {
+    throw(  
+ v   )=>v;
+});


### PR DESCRIPTION
**Describe your changes**

fixes #29

Given:

```ts
return<T>
(v: T) => v
```

We need to ensure the arrow function is still returned after erasing the type argument. This is achieved by moving the opening parentheses up:

```js
return(
 v: T) => v
```

**Testing performed**

Additional test fixtures have been added.
