### PR TITLE
test: add more namespace fixtures

### DIFF
--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -111,6 +111,32 @@ it("errors on instantiated namespaces due to having runtime emit", () => {
     );
 });
 
+it("importing instantiated namespace", () => {
+    const onError = mock.fn();
+    const out = tsBlankSpace(
+        `
+        namespace A { export let x = 1; }
+        namespace B { import x = A.x; }
+        namespace C { export import x = A.x; }
+        `,
+        onError,
+    );
+    assert.equal(onError.mock.callCount(), 2);
+    const errorNodeNames = errorCallbackToModuleDeclarationNames(onError);
+    assert.deepEqual(errorNodeNames, ["A", "C"]);
+    // Only 'B' is erased:
+    assert.equal(
+        out,
+        [
+            ``,
+            `        namespace A { export let x = 1; }`,
+            `        ;                              `,
+            `        namespace C { export import x = A.x; }`,
+            `        `,
+        ].join("\n"),
+    );
+});
+
 it("errors on CJS export assignment syntax", () => {
     const onError = mock.fn();
     const out = tsBlankSpace(

--- a/tests/fixture/cases/namespaces.ts
+++ b/tests/fixture/cases/namespaces.ts
@@ -30,6 +30,13 @@ declare namespace Declared {
     export function foo(): void
 }
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `declare namespace`
+
+export namespace ValueImport {
+    import foo = Declared.foo;
+    export type T = typeof foo;
+}
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ // _value_ import namespace
+
 Declared.foo(); // May throw at runtime if declaration was false
 
 export const x: With.Imports.Foo = 1;

--- a/tests/fixture/output/namespaces.js
+++ b/tests/fixture/output/namespaces.js
@@ -30,6 +30,13 @@
                                
  
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `declare namespace`
+
+                              
+                              
+                               
+ 
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ // _value_ import namespace
+
 Declared.foo(); // May throw at runtime if declaration was false
 
 export const x                   = 1;


### PR DESCRIPTION
Follow on from https://github.com/bloomberg/ts-blank-space/pull/32#discussion_r1938218228.

This PR adds more test fixtures to cover `import V = ..` that reference values.

Showing that they, on their own, do not cause the namespace to become instantiated.
Note that all `export import V = ...` prevent the namespace from being erased, even if the import was for a type.

cc: @magic-akari