### PR TITLE
feat: drop support for legacy module namespaces

### DIFF
--- a/docs/unsupported_syntax.md
+++ b/docs/unsupported_syntax.md
@@ -9,7 +9,7 @@ The following TypeScript features can not be erased by `ts-blank-space` because 
 
 -   `enum` (unless `declare enum`) [more details](#enums)
 -   `namespace` (unless only contains types) [more details](#namespace-declarations)
--   `module` (unless `declare module`) [more details](#module-namespace-declarations)
+-   `module` (unless `declare module "path"`) [more details](#module-namespace-declarations)
 -   `import lib = ...`, `export = ...` (TypeScript style CommonJS)
 -   `constructor(public x) {}` [more details](#constructor-parameter-properties)
 
@@ -78,15 +78,22 @@ Examples of supported namespace syntax can be seen in the test fixture [tests/fi
 
 ### `module` namespace declarations
 
-`ts-blank-space` only erases TypeScript's `module` namespace declarations if they are marked with `declare` (see [`declare` hazard](#the-declare--hazard)).
+`ts-blank-space` only erases TypeScript's `module` statements if they are [ambient module augmentations](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).
 
-All other TypeScript `module` declarations will trigger the `onError` callback and be left in the output text verbatim. Including an empty declaration:
+All other TypeScript `module` declarations will trigger the `onError` callback and be left in the output text verbatim.
 
 ```ts
-module M {} // `ts-blank-space` error
+// erasable ambient module augmentation:
+declare module "./path" {}
 ```
 
-Note that, since TypeScript 5.6, use of `module` namespace declarations (not to be confused with _"ambient module declarations"_) will be shown with a strike-through (~~`module`~~) to hint that the syntax is deprecated in favour of [`namespace`](#namespace-declarations).
+```ts
+// deprecated module namespaces:
+module M1 {} // `ts-blank-space` error
+declare module M2 {} // `ts-blank-space` error
+```
+
+Note that, since TypeScript 5.6, use of `module` namespace declarations will be shown with a strike-through (~~`module`~~) to hint that the syntax is deprecated in favour of [`namespace`](#namespace-declarations).
 
 See https://github.com/microsoft/TypeScript/issues/51825 for more information.
 

--- a/docs/unsupported_syntax.md
+++ b/docs/unsupported_syntax.md
@@ -78,7 +78,7 @@ Examples of supported namespace syntax can be seen in the test fixture [tests/fi
 
 ### `module` namespace declarations
 
-`ts-blank-space` only erases TypeScript's `module` statements if they are [ambient module augmentations](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).
+`ts-blank-space` only erases TypeScript's `module` statements if they represent [Ambient Modules](https://www.typescriptlang.org/docs/handbook/modules/reference.html#ambient-modules) and applies to both _Ambient Module Augmentations_ as well as _Ambient Module Declarations_.
 
 All other TypeScript `module` declarations will trigger the `onError` callback and be left in the output text verbatim.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ts-blank-space",
-    "version": "0.5.1",
+    "version": "0.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ts-blank-space",
-            "version": "0.5.1",
+            "version": "0.6.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "typescript": "5.1.6 - 5.7.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-blank-space",
     "description": "A small, fast, pure JavaScript type-stripper that uses the official TypeScript parser.",
-    "version": "0.5.1",
+    "version": "0.6.0",
     "license": "Apache-2.0",
     "homepage": "https://bloomberg.github.io/ts-blank-space",
     "contributors": [

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -137,6 +137,20 @@ it("importing instantiated namespace", () => {
     );
 });
 
+it("errors on declared legacy modules", () => {
+    const onError = mock.fn();
+    const out = tsBlankSpace(`declare module M {}\n`, onError);
+    assert.equal(onError.mock.callCount(), 1);
+    assert.equal(out, "declare module M {}\n");
+});
+
+it("errors on non-instantiated legacy modules", () => {
+    const onError = mock.fn();
+    const out = tsBlankSpace(`module M {}\n`, onError);
+    assert.equal(onError.mock.callCount(), 1);
+    assert.equal(out, "module M {}\n");
+});
+
 it("errors on CJS export assignment syntax", () => {
     const onError = mock.fn();
     const out = tsBlankSpace(

--- a/tests/fixture/cases/a.ts
+++ b/tests/fixture/cases/a.ts
@@ -102,8 +102,13 @@ void 0;
 
 void 0;
 
-/**/declare module M {}
-//  ^^^^^^^^^^^^^^^^^^^ `declare module`
+/**/declare module "./a" {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^ `declare module "path"`
+
+void 0;
+
+/**/declare global {}
+//  ^^^^^^^^^^^^^^^^^ `declare global {}`
 
 void 0;
 

--- a/tests/fixture/output/a.js
+++ b/tests/fixture/output/a.js
@@ -102,8 +102,13 @@ void 0;
 
 void 0;
 
-/**/;                  
-//  ^^^^^^^^^^^^^^^^^^^ `declare module`
+/**/;                      
+//  ^^^^^^^^^^^^^^^^^^^^^^^ `declare module "path"`
+
+void 0;
+
+/**/;                
+//  ^^^^^^^^^^^^^^^^^ `declare global {}`
 
 void 0;
 

--- a/tests/valid.test.ts
+++ b/tests/valid.test.ts
@@ -92,11 +92,18 @@ it("allows declared namespace value", () => {
     assert.equal(jsOutput, "                      \n");
 });
 
-it("allows declared module value", () => {
+it("allows declared module augmentation value", () => {
     const onError = mock.fn();
-    const jsOutput = tsBlankSpace(`declare module M {}\n`, onError);
+    const jsOutput = tsBlankSpace(`declare module "" {}\n`, onError);
     assert.equal(onError.mock.callCount(), 0);
-    assert.equal(jsOutput, "                   \n");
+    assert.equal(jsOutput, "                    \n");
+});
+
+it("allows declared global augmentation value", () => {
+    const onError = mock.fn();
+    const jsOutput = tsBlankSpace(`declare global {}\n`, onError);
+    assert.equal(onError.mock.callCount(), 0);
+    assert.equal(jsOutput, "                 \n");
 });
 
 it("TSX is preserved in the output", () => {


### PR DESCRIPTION
## Context

https://github.com/microsoft/TypeScript/issues/51825
https://github.com/nodejs/amaro/issues/168

## Description 

This PR is a *breaking change*.
Continuing on from #32 but instead of allowing _more_ `ModuleDeclaration` AST nodes, this PR removes support for erasing namespace declarations that use the deprecated `module` keyword.

### Still erased (no error emitted)

```ts
declare namespace N1 {}
namespace N2 {}
declare global {}
declare module "./path" {}
```

### No longer erased (triggers `onError` callback)

```ts
declare module M1 {}
module M2 {}
```

