### PR TITLE
feat: update to TypeScript 5.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ When unsupported syntax is encountered, `ts-blank-space` will call the optional 
     // Because imports and exports are preserved as written, only removing the
     // parts which are explicitly annotated with the `type` keyword
     "verbatimModuleSyntax": true,
+    // As of `typescript@5.8` there is a built-in check to error on the non-erasable
+    // syntax that tools such as `ts-blank-space` don't support e.g. parameter properties.
+    "erasableSyntaxOnly": true,
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "ts-blank-space",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ts-blank-space",
-            "version": "0.6.0",
+            "version": "0.6.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "typescript": "5.1.6 - 5.7.x"
+                "typescript": "5.1.6 - 5.8.x"
             },
             "devDependencies": {
                 "@types/node": "^20.9.4",
@@ -21,12 +21,13 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "20.14.9",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-            "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+            "version": "20.17.22",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.22.tgz",
+            "integrity": "sha512-9RV2zST+0s3EhfrMZIhrz2bhuhBwxgkbHEwP2gtGWPjBzVQjifMzJ9exw7aDZhR1wbpj8zBrfp3bo8oJcGiUUw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "undici-types": "~5.26.4"
+                "undici-types": "~6.19.2"
             }
         },
         "node_modules/prettier": {
@@ -34,11 +35,15 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
             "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
             "engines": {
                 "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/ts-blank-space-lkg": {
@@ -47,6 +52,7 @@
             "resolved": "https://registry.npmjs.org/ts-blank-space/-/ts-blank-space-0.3.3333.tgz",
             "integrity": "sha512-8ODEgOZd4nvaGjIWDYB/Zw5NH3ioHfBcrokoF/gdhVpIRXZhFzkcrJ36n9es6A6hVhydrDswaNO/5OSHQoq22A==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "typescript": "5.1.6 - 5.6.x"
             },
@@ -69,9 +75,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+            "version": "5.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -82,10 +88,11 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-            "dev": true
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+            "dev": true,
+            "license": "MIT"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-blank-space",
     "description": "A small, fast, pure JavaScript type-stripper that uses the official TypeScript parser.",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "license": "Apache-2.0",
     "homepage": "https://bloomberg.github.io/ts-blank-space",
     "contributors": [
@@ -23,7 +23,7 @@
     },
     "types": "./out/index.d.ts",
     "dependencies": {
-        "typescript": "5.1.6 - 5.7.x"
+        "typescript": "5.1.6 - 5.8.x"
     },
     "imports": {
         "#r": "ts-blank-space-lkg/register"

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -6,6 +6,7 @@
         "moduleDetection": "force",
         "verbatimModuleSyntax": true,
         "useDefineForClassFields": true,
+        "erasableSyntaxOnly": true,
         "declaration": true,
         "declarationDir": "../out"
     },


### PR DESCRIPTION
Closes #42 

This PR sets the recently released TypeScript 5.8 version as the highest known supported version.

It also updates the README to mention the new and exciting `erasableSyntaxOnly` flag.