### PR TITLE
feat: update to TypeScript 5.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.6.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "typescript": "5.1.6 - 5.8.x"
+                "typescript": "5.1.6 - 5.9.x"
             },
             "devDependencies": {
                 "@types/node": "^20.9.4",
@@ -75,9 +75,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.8.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+            "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "types": "./out/index.d.ts",
     "dependencies": {
-        "typescript": "5.1.6 - 5.8.x"
+        "typescript": "5.1.6 - 5.9.x"
     },
     "imports": {
         "#r": "ts-blank-space-lkg/register"


### PR DESCRIPTION
*Issue number of the reported bug or feature request: None*

**Describe your changes**

This PR sets the recently released TypeScript 5.9 version as the highest known supported version.

**Testing performed**

I've run `npm run test` and `npm run test-ecosystem` and all tests have passed.

**Additional context**

- https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/
