### PR TITLE
fix(website): Align TypeScript version in website with package

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "monaco-editor": "^0.50.0",
         "ts-blank-space": "..",
-        "typescript": "^5.5.4"
+        "typescript": "^6.0.2"
     },
     "devDependencies": {
         "@11ty/eleventy": "3.0.0",


### PR DESCRIPTION
This aligns the version of TypeScript used in the playground with the one in the root of the repo.