### PR TITLE
fix: Error for problematic type assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The benefits of this library are:
     -   No [native-addons](https://nodejs.org/api/addons.html)
     -   No [child process](https://nodejs.org/api/child_process.html)
 -   It is small
-    -   Around 700 lines of code and one dependency ([`TypeScript`](https://www.npmjs.com/package/typescript))
+    -   Around 800 lines of code and one dependency ([`TypeScript`](https://www.npmjs.com/package/typescript))
     -   By doing so little, the code should be relatively easy to maintain
 -   Delegates the parsing to the [official TypeScript parser](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API)
 -   No need for additional SourceMap processing; see ["where are my SourceMaps?"](#where-are-my-sourcemaps)
@@ -222,6 +222,8 @@ let f = async (
 ## Unsupported Syntax
 
 Some parts of TypeScript are not supported because they can't be erased in place due to having runtime semantics. See [unsupported_syntax.md](./docs/unsupported_syntax.md).
+
+In addition, some compile-time-only assertion forms such as `as` / `satisfies` can still be unsupported in specific precedence-sensitive positions, because erasing them would require adding parentheses to keep JavaScript semantics the same.
 
 When unsupported syntax is encountered, `ts-blank-space` will call the optional `onError` callback and continue. Examples can be seen in [`errors.test.ts`](./tests/errors.test.ts).
 

--- a/docs/unsupported_syntax.md
+++ b/docs/unsupported_syntax.md
@@ -203,13 +203,6 @@ Supported (safe to erase) example:
 
 After erasure, grouping is still effectively `(1 * 1) + 2`, so this is supported.
 
-The same applies to nested assertion chains, for example:
-
-<!-- prettier-ignore -->
-```typescript
-1 + 1 as unknown as number / 2;
-```
-
 Thanks to [Masaki Hara](https://github.com/qnighy) for [identifying this restriction](https://github.com/bloomberg/ts-blank-space/issues/62).
 
 ### Legacy prefix type assertions

--- a/docs/unsupported_syntax.md
+++ b/docs/unsupported_syntax.md
@@ -143,6 +143,77 @@ Further reading on decorators:
 
 ## Compile time only syntax
 
+-   Legacy prefix type assertions (for example `<const>value`) are not erased [more details](#legacy-prefix-type-assertions)
+-   Some trailing `as` / `satisfies` expressions are not erased when removing them would change binary operator grouping [more details](#as--satisfies-expressions-that-would-change-operator-grouping)
+
+### `as` / `satisfies` expressions that would change operator grouping
+
+In most cases, `as` and `satisfies` are erased in place. However, some forms require TypeScript to add parentheses to preserve runtime semantics. Since `ts-blank-space` preserves the source positions, these cases are reported through `onError` and left unchanged.
+
+Simple example that will error:
+
+<!-- prettier-ignore -->
+```typescript
+1 + 1 as number / 2;
+```
+
+TypeScript would effectively group that as:
+
+<!-- prettier-ignore -->
+```javascript
+(1 + 1) / 2;
+```
+
+Erasing only the assertion text would incorrectly produce:
+
+<!-- prettier-ignore -->
+```javascript
+1 + 1           / 2;
+```
+
+Which has the semantics of `1 + (1 / 2)`. So this is not supported and `onError` is called.
+
+Note, the precedence of the two runtime operators determines if this is erasable or an error.
+
+Given:
+
+<!-- prettier-ignore -->
+```typescript
+left OP1 right as T OP2 tail
+```
+
+`ts-blank-space` looks at:
+
+-   `OP1`: the operator inside the asserted binary expression (`left OP1 right`)
+-   `OP2`: the next operator immediately after the assertion chain
+
+Then applies the following rules:
+
+-   If `OP2` has **higher precedence** than `OP1`, erasing would re-group evaluation, so `onError` is called and the assertion text is preserved.
+-   If `OP2` has **lower precedence** than `OP1`, erasing keeps grouping unchanged, so the assertion is erased.
+-   If `OP2` has **equal precedence**, erasure is usually safe, except for cases that are not safely associative (for example `**`).
+-   The same check applies to chained assertions like `expr as A as B` and `expr satisfies A as B`.
+
+Supported (safe to erase) example:
+
+<!-- prettier-ignore -->
+```typescript
+1 * 1 as number + 2;
+```
+
+After erasure, grouping is still effectively `(1 * 1) + 2`, so this is supported.
+
+The same applies to nested assertion chains, for example:
+
+<!-- prettier-ignore -->
+```typescript
+1 + 1 as unknown as number / 2;
+```
+
+Thanks to [Masaki Hara](https://github.com/qnighy) for [identifying this restriction](https://github.com/bloomberg/ts-blank-space/issues/62).
+
+### Legacy prefix type assertions
+
 TypeScript type assertions have no runtime semantics, however `ts-blank-space` does not erase the legacy prefix-style type assertions.
 
 <!-- prettier-ignore -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ts-blank-space",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ts-blank-space",
-            "version": "0.8.0",
+            "version": "0.9.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "typescript": "5.1.6 - 6.0.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-blank-space",
     "description": "A small, fast, pure JavaScript type-stripper that uses the official TypeScript parser.",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "license": "Apache-2.0",
     "homepage": "https://bloomberg.github.io/ts-blank-space",
     "contributors": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ function innerVisitor(node: ts.Node, kind: ts.SyntaxKind): VisitResult {
         case SK.InterfaceDeclaration:
             blankStatement(node as (ts.TypeAliasDeclaration | ts.InterfaceDeclaration));
             return VISIT_BLANKED;
+        case SK.BinaryExpression: return visitBinaryExpression(node as ts.BinaryExpression);
         case SK.ClassDeclaration:
         case SK.ClassExpression: return visitClassLike(node as ts.ClassLikeDeclaration);
         case SK.ExpressionWithTypeArguments: return visitExpressionWithTypeArguments(node as ts.ExpressionWithTypeArguments);
@@ -379,6 +380,48 @@ function isAssertionExpression(node: ts.Node): node is ts.AsExpression | ts.Sati
     return node.kind === SK.AsExpression || node.kind === SK.SatisfiesExpression;
 }
 
+/**
+ * Detect if erasing a type-assertion annotation would result in a runtime
+ * syntax error due to unparenthesized mixing of `??` with `&&` or `||`.
+ * e.g. In `a ?? b as T && c` erasing `as T` would produce `a ?? b && c` which is a SyntaxError.
+ */
+function visitBinaryExpression(node: ts.BinaryExpression): VisitResult {
+    const opKind = node.operatorToken.kind;
+    if (isNullishOrLogical(opKind)) {
+        if (
+            tslib.isBinaryExpression(node.right) &&
+            hasUnsafeNullishLogicalMix(opKind, node.right.operatorToken.kind) &&
+            isAssertionExpression(node.right.left)
+        ) {
+            // e.g. `a ?? b as T && c` parses as `??[a, &&[as[b, T], c]]`
+            visitor(node.left);
+            onError && onError(node.right.left);
+            visitor(node.right.right);
+            return VISITED_JS;
+        }
+        if (
+            tslib.isBinaryExpression(node.left) &&
+            hasUnsafeNullishLogicalMix(opKind, node.left.operatorToken.kind) &&
+            isAssertionExpression(node.left.right)
+        ) {
+            // e.g. `a && b as T ?? c` parses as `??[&&[a, as[b, T]], c]`
+            //   or `a || b as T ?? c` parses as `??[||[a, as[b, T]], c]`
+            //   or `a ?? b as T || c` parses as `||[??[a, as[b, T]], c]`
+            visitor(node.left.left);
+            onError && onError(node.left.right);
+            visitor(node.right);
+            return VISITED_JS;
+        }
+    }
+    visitor(node.left);
+    visitor(node.right);
+    return VISITED_JS;
+}
+
+/**
+ * Detect cases where erasing a type assertion would change operator grouping. e.g. `1 + 1 as T / 2`
+ * @see https://github.com/bloomberg/ts-blank-space/issues/62
+ */
 function assertionChainWouldChangeBinaryGrouping(node: ts.AsExpression | ts.SatisfiesExpression): boolean {
     let baseExpr: ts.Expression = node.expression;
     while (isAssertionExpression(baseExpr)) {
@@ -389,27 +432,19 @@ function assertionChainWouldChangeBinaryGrouping(node: ts.AsExpression | ts.Sati
         return false;
     }
 
-    let chainTop: ts.Node = node;
-    while (chainTop.parent && isAssertionExpression(chainTop.parent) && chainTop.parent.expression === chainTop) {
-        chainTop = chainTop.parent;
-    }
-
-    const nextToken = scanRange(chainTop.end, ast.end, scanner.scan.bind(scanner));
+    const nextToken = scanRange(node.end, ast.end, scanner.scan.bind(scanner));
     const basePrecedence = getBinaryOperatorPrecedence(baseExpr.operatorToken.kind);
     const nextPrecedence = getBinaryOperatorPrecedence(nextToken);
     if (basePrecedence === undefined || nextPrecedence === undefined) {
         return false;
     }
 
-    if (hasUnsafeNullishLogicalMix(baseExpr.operatorToken.kind, nextToken)) {
-        return true;
-    }
-
     if (nextPrecedence > basePrecedence) {
-        return true;
+        return true; // higher next precedence is unsafe, the grouping would change
     }
 
     if (nextPrecedence === basePrecedence) {
+        // Only right-associative is unsafe e.g. `**`
         return !areOperatorsSafelyAssociative(baseExpr.operatorToken.kind, nextToken);
     }
 
@@ -464,11 +499,12 @@ function isNullishOrLogical(token: ts.SyntaxKind): boolean {
     return token === SK.QuestionQuestionToken || token === SK.BarBarToken || token === SK.AmpersandAmpersandToken;
 }
 
+// JavaScript requires explicit parentheses when mixing `??` with `||` or `&&`.
 function hasUnsafeNullishLogicalMix(left: ts.SyntaxKind, right: ts.SyntaxKind): boolean {
-    if (!isNullishOrLogical(left) || !isNullishOrLogical(right)) {
-        return false;
-    }
-    return left !== right;
+    if (left === right) return false;
+    if (left === SK.QuestionQuestionToken) return isNullishOrLogical(right);
+    if (right === SK.QuestionQuestionToken) return isNullishOrLogical(left);
+    return false;
 }
 
 function areOperatorsSafelyAssociative(left: ts.SyntaxKind, right: ts.SyntaxKind): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -352,6 +352,11 @@ function visitNonNullExpression(node: ts.NonNullExpression): VisitResult {
  * `exp satisfies T, exp as T`
  */
 function visitTypeAssertion(node: ts.SatisfiesExpression | ts.AsExpression): VisitResult {
+    if (assertionChainWouldChangeBinaryGrouping(node)) {
+        onError && onError(node);
+        return VISITED_JS;
+    }
+
     const r = visitor(node.expression);
     const nodeEnd = node.end;
     if (parentStatement && nodeEnd === parentStatement.end && src.charCodeAt(nodeEnd) !== 59 /* ; */) {
@@ -368,6 +373,110 @@ function visitTypeAssertion(node: ts.SatisfiesExpression | ts.AsExpression): Vis
 function visitLegacyTypeAssertion(node: ts.TypeAssertion): VisitResult {
     onError && onError(node);
     return visitor(node.expression);
+}
+
+function isAssertionExpression(node: ts.Node): node is ts.AsExpression | ts.SatisfiesExpression {
+    return node.kind === SK.AsExpression || node.kind === SK.SatisfiesExpression;
+}
+
+function assertionChainWouldChangeBinaryGrouping(node: ts.AsExpression | ts.SatisfiesExpression): boolean {
+    let baseExpr: ts.Expression = node.expression;
+    while (isAssertionExpression(baseExpr)) {
+        baseExpr = baseExpr.expression;
+    }
+
+    if (!tslib.isBinaryExpression(baseExpr)) {
+        return false;
+    }
+
+    let chainTop: ts.Node = node;
+    while (chainTop.parent && isAssertionExpression(chainTop.parent) && chainTop.parent.expression === chainTop) {
+        chainTop = chainTop.parent;
+    }
+
+    const nextToken = scanRange(chainTop.end, ast.end, scanner.scan.bind(scanner));
+    const basePrecedence = getBinaryOperatorPrecedence(baseExpr.operatorToken.kind);
+    const nextPrecedence = getBinaryOperatorPrecedence(nextToken);
+    if (basePrecedence === undefined || nextPrecedence === undefined) {
+        return false;
+    }
+
+    if (hasUnsafeNullishLogicalMix(baseExpr.operatorToken.kind, nextToken)) {
+        return true;
+    }
+
+    if (nextPrecedence > basePrecedence) {
+        return true;
+    }
+
+    if (nextPrecedence === basePrecedence) {
+        return !areOperatorsSafelyAssociative(baseExpr.operatorToken.kind, nextToken);
+    }
+
+    return false;
+}
+
+function getBinaryOperatorPrecedence(token: ts.SyntaxKind): number | undefined {
+    switch (token) {
+        case SK.AsteriskAsteriskToken:
+            return 15;
+        case SK.AsteriskToken:
+        case SK.SlashToken:
+        case SK.PercentToken:
+            return 14;
+        case SK.PlusToken:
+        case SK.MinusToken:
+            return 13;
+        case SK.LessThanLessThanToken:
+        case SK.GreaterThanGreaterThanToken:
+        case SK.GreaterThanGreaterThanGreaterThanToken:
+            return 12;
+        case SK.LessThanToken:
+        case SK.LessThanEqualsToken:
+        case SK.GreaterThanToken:
+        case SK.GreaterThanEqualsToken:
+        case SK.InstanceOfKeyword:
+        case SK.InKeyword:
+            return 11;
+        case SK.EqualsEqualsToken:
+        case SK.ExclamationEqualsToken:
+        case SK.EqualsEqualsEqualsToken:
+        case SK.ExclamationEqualsEqualsToken:
+            return 10;
+        case SK.AmpersandToken:
+            return 9;
+        case SK.CaretToken:
+            return 8;
+        case SK.BarToken:
+            return 7;
+        case SK.AmpersandAmpersandToken:
+            return 6;
+        case SK.BarBarToken:
+            return 5;
+        case SK.QuestionQuestionToken:
+            return 4;
+        default:
+            return undefined;
+    }
+}
+
+function isNullishOrLogical(token: ts.SyntaxKind): boolean {
+    return token === SK.QuestionQuestionToken || token === SK.BarBarToken || token === SK.AmpersandAmpersandToken;
+}
+
+function hasUnsafeNullishLogicalMix(left: ts.SyntaxKind, right: ts.SyntaxKind): boolean {
+    if (!isNullishOrLogical(left) || !isNullishOrLogical(right)) {
+        return false;
+    }
+    return left !== right;
+}
+
+function areOperatorsSafelyAssociative(left: ts.SyntaxKind, right: ts.SyntaxKind): boolean {
+    // Exponentiation is right-associative, so `(a ** b) ** c` and `a ** b ** c` differ.
+    if (left === SK.AsteriskAsteriskToken || right === SK.AsteriskAsteriskToken) {
+        return false;
+    }
+    return true;
 }
 
 const unsupportedParameterModifiers = new Set([

--- a/src/index.ts
+++ b/src/index.ts
@@ -444,8 +444,8 @@ function assertionChainWouldChangeBinaryGrouping(node: ts.AsExpression | ts.Sati
     }
 
     if (nextPrecedence === basePrecedence) {
-        // Only right-associative is unsafe e.g. `**`
-        return !areOperatorsSafelyAssociative(baseExpr.operatorToken.kind, nextToken);
+        // Exponentiation is unsafe as it is right-associative. `(2 ** 2) ** 3` !== `2 ** 2 ** 3`.
+        return baseExpr.operatorToken.kind === SK.AsteriskAsteriskToken || nextToken === SK.AsteriskAsteriskToken;
     }
 
     return false;
@@ -505,14 +505,6 @@ function hasUnsafeNullishLogicalMix(left: ts.SyntaxKind, right: ts.SyntaxKind): 
     if (left === SK.QuestionQuestionToken) return isNullishOrLogical(right);
     if (right === SK.QuestionQuestionToken) return isNullishOrLogical(left);
     return false;
-}
-
-function areOperatorsSafelyAssociative(left: ts.SyntaxKind, right: ts.SyntaxKind): boolean {
-    // Exponentiation is right-associative, so `(a ** b) ** c` and `a ** b ** c` differ.
-    if (left === SK.AsteriskAsteriskToken || right === SK.AsteriskAsteriskToken) {
-        return false;
-    }
-    return true;
 }
 
 const unsupportedParameterModifiers = new Set([

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -185,7 +185,7 @@ it("errors on CJS import syntax", () => {
     );
 });
 
-it("errors on `as` expression that would change operator precedence", () => {
+it("errors on `as` expression that would change operator precedence if erased", () => {
     const onError = mock.fn();
     const tsInput = `1+1 as T / 2`;
     let jsOutput = tsBlankSpace(tsInput, onError);
@@ -195,7 +195,17 @@ it("errors on `as` expression that would change operator precedence", () => {
     assert.equal(jsOutput, `1+1 as T / 2`);
 });
 
-it("errors on nested `as` expressions that would change operator precedence", () => {
+it("errors on (invalid) `as const` expression that would change operator precedence if evaluated", () => {
+    const onError = mock.fn();
+    const tsInput = `1+1 as const / 2`;
+    let jsOutput = tsBlankSpace(tsInput, onError);
+    assert.equal(onError.mock.callCount(), 1);
+    // TypeScript would emit `(1+1) / 2`, but ts-blank-space can't insert
+    // the leading `(` without shifting offsets, so it must error.
+    assert.equal(jsOutput, `1+1 as const / 2`);
+});
+
+it("errors on nested `as` expressions that would change operator precedence if erased", () => {
     const onError = mock.fn();
     const tsInput = `1 + 1 as unknown as number / 2`;
     const jsOutput = tsBlankSpace(tsInput, onError);
@@ -203,12 +213,89 @@ it("errors on nested `as` expressions that would change operator precedence", ()
     assert.equal(jsOutput, `1 + 1 as unknown as number / 2`);
 });
 
+it("errors on (invalid) ambiguous `??` precedence that would error if erased", () => {
+    logicalOr: {
+        const onError = mock.fn();
+        // TypeScript produces an error for this input:
+        const tsInput = `a ?? b as any || 2`; // "ts(5076): '??' and '||' operations cannot be mixed without parentheses"
+        // If that TS error was ignored the TS emitted code would actually be valid
+        // because TS adds parenthesis: `(a ?? b) || 2`.
+        // `ts-blank-space` would only erase, meaning there would be a runtime syntax error.
+        // To catch this early we should emit an error.
+        const jsOutput = tsBlankSpace(tsInput, onError);
+        assert.equal(onError.mock.callCount(), 1);
+        assert.equal(jsOutput, `a ?? b as any || 2`);
+    }
+
+    logicalAnd: {
+        const onError = mock.fn();
+        const tsInput = `a ?? b as any && 2`; // "ts(5076): '??' and '||' operations cannot be mixed without parentheses"
+        const jsOutput = tsBlankSpace(tsInput, onError);
+        assert.equal(onError.mock.callCount(), 1);
+        assert.equal(jsOutput, `a ?? b as any && 2`);
+    }
+
+    logicalOrReversed: {
+        const onError = mock.fn();
+        const tsInput = `a || b as any ?? 2`;
+        const jsOutput = tsBlankSpace(tsInput, onError);
+        assert.equal(onError.mock.callCount(), 1);
+        assert.equal(jsOutput, `a || b as any ?? 2`);
+    }
+
+    logicalAndReversed: {
+        const onError = mock.fn();
+        const tsInput = `a && b as any ?? 2`;
+        const jsOutput = tsBlankSpace(tsInput, onError);
+        assert.equal(onError.mock.callCount(), 1);
+        assert.equal(jsOutput, `a && b as any ?? 2`);
+    }
+
+    satisfies: {
+        const onError = mock.fn();
+        const tsInput = `a ?? b satisfies any || 2`;
+        const jsOutput = tsBlankSpace(tsInput, onError);
+        assert.equal(onError.mock.callCount(), 1);
+        assert.equal(jsOutput, `a ?? b satisfies any || 2`);
+    }
+
+    assertionChain: {
+        const onError = mock.fn();
+        const tsInput = `a ?? b as any as unknown && 2`;
+        const jsOutput = tsBlankSpace(tsInput, onError);
+        assert.equal(onError.mock.callCount(), 1);
+        assert.equal(jsOutput, `a ?? b as any as unknown && 2`);
+    }
+});
+
+it("errors on `??` mix nested inside a larger expression", () => {
+    threeOperatorChain: {
+        // `a ?? b as T && c || d` parses as `||[??[a, &&[as[b, T], c]], d]`
+        // The ?? mix error is caught at the inner `??` node
+        const onError = mock.fn();
+        const tsInput = `a ?? b as T && c || d`;
+        const jsOutput = tsBlankSpace(tsInput, onError);
+        assert.equal(onError.mock.callCount(), 1);
+        assert.equal(jsOutput, `a ?? b as T && c || d`);
+    }
+
+    precedenceErrorDeeperInTree: {
+        // `1 + 2 as T * 3 + 4` parses as `+[*[as[+[1, 2], T], 3], 4]`
+        // The precedence error (+ vs *) is caught on the nested `as` node
+        const onError = mock.fn();
+        const tsInput = `1 + 2 as T * 3 + 4`;
+        const jsOutput = tsBlankSpace(tsInput, onError);
+        assert.equal(onError.mock.callCount(), 1);
+        assert.equal(jsOutput, `1 + 2 as T * 3 + 4`);
+    }
+});
+
 it("errors even with comments between assertion chain and next operator", () => {
     const onError = mock.fn();
     const tsInput = `1 + 1 as unknown /* comment */ / 2`;
     const jsOutput = tsBlankSpace(tsInput, onError);
     assert.equal(onError.mock.callCount(), 1);
-    assert.equal(jsOutput, tsInput);
+    assert.equal(jsOutput, `1 + 1 as unknown /* comment */ / 2`);
 });
 
 it("covers assertion-chain binary precedence error cases across operators", () => {

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -185,6 +185,74 @@ it("errors on CJS import syntax", () => {
     );
 });
 
+it("errors on `as` expression that would change operator precedence", () => {
+    const onError = mock.fn();
+    const tsInput = `1+1 as T / 2`;
+    let jsOutput = tsBlankSpace(tsInput, onError);
+    assert.equal(onError.mock.callCount(), 1);
+    // TypeScript would emit `(1+1) / 2`, but ts-blank-space can't insert
+    // the leading `(` without shifting offsets, so it must error.
+    assert.equal(jsOutput, `1+1 as T / 2`);
+});
+
+it("errors on nested `as` expressions that would change operator precedence", () => {
+    const onError = mock.fn();
+    const tsInput = `1 + 1 as unknown as number / 2`;
+    const jsOutput = tsBlankSpace(tsInput, onError);
+    assert.equal(onError.mock.callCount(), 1);
+    assert.equal(jsOutput, `1 + 1 as unknown as number / 2`);
+});
+
+it("errors even with comments between assertion chain and next operator", () => {
+    const onError = mock.fn();
+    const tsInput = `1 + 1 as unknown /* comment */ / 2`;
+    const jsOutput = tsBlankSpace(tsInput, onError);
+    assert.equal(onError.mock.callCount(), 1);
+    assert.equal(jsOutput, tsInput);
+});
+
+it("covers assertion-chain binary precedence error cases across operators", () => {
+    const runErrorCase = (input: string, context: string) => {
+        const onError = mock.fn();
+        const jsOutput = tsBlankSpace(input, onError);
+        assert.equal(onError.mock.callCount(), 1, `unexpected onError count: ${context}`);
+        assert.equal(jsOutput, input, `should preserve source when it errors: ${context}`);
+    };
+
+    runErrorCase(`1 ** 1 as unknown ** 2`, "same operator **");
+
+    const higherPrecedenceCases = [
+        { base: "<", next: "<<" },
+        { base: "<=", next: "<<" },
+        { base: ">", next: "<<" },
+        { base: ">=", next: "<<" },
+        { base: "instanceof", next: "<<" },
+        { base: "in", next: "<<" },
+        { base: "<<", next: "+" },
+        { base: ">>", next: "+" },
+        { base: ">>>", next: "+" },
+        { base: "+", next: "*" },
+        { base: "-", next: "*" },
+        { base: "*", next: "**" },
+        { base: "/", next: "**" },
+        { base: "%", next: "**" },
+    ];
+
+    for (const { base, next } of higherPrecedenceCases) {
+        runErrorCase(`a ${base} a as unknown ${next} a`, `${next} should outrank ${base}`);
+    }
+
+    runErrorCase(`1 + 1 as unknown * 2`, "targeted higher-precedence operator");
+});
+
+it("errors on `satisfies` expression that would change operator precedence", () => {
+    const onError = mock.fn();
+    const tsInput = `1+1 satisfies T / 2`;
+    let jsOutput = tsBlankSpace(tsInput, onError);
+    assert.equal(onError.mock.callCount(), 1);
+    assert.equal(jsOutput, `1+1 satisfies T / 2`);
+});
+
 it("errors on prefix type assertion", () => {
     const onError = mock.fn();
     const tsInput = `let x = <string>"test";`;

--- a/tests/fixture/cases/assertion-precedence-non-errors.ts
+++ b/tests/fixture/cases/assertion-precedence-non-errors.ts
@@ -1,49 +1,56 @@
+let a:any, b:any, c:any;
+type T = any;
+
+// Operator is a TypeScript type operator
+a & b as any & T;
+//    ^^^^^^^^^^
+a | b as unknown | T;
+//    ^^^^^^^^^^^^^^
+
 // Same-operator cases that should erase without error:
-1 * 1 as unknown * 2;
-1 / 1 as unknown / 2;
-1 % 1 as unknown % 2;
-1 + 1 as unknown + 2;
-1 - 1 as unknown - 2;
-1 << 1 as unknown << 2;
-1 >> 1 as unknown >> 2;
-1 >>> 1 as unknown >>> 2;
-1 < 1 as unknown < 2;
-1 <= 1 as unknown <= 2;
-1 > 1 as unknown > 2;
-1 >= 1 as unknown >= 2;
+1 * 1 as number * 2;
+1 / 1 as number / 2;
+1 % 1 as number % 2;
+1 + 1 as number + 2;
+1 - 1 as number - 2;
+1 << 1 as number << 2;
+1 >> 1 as number >> 2;
+1 >>> 1 as number >>> 2;
+1 < 1 as any < 2;
+1 <= 1 as any <= 2;
+1 > 1 as any > 2;
+1 >= 1 as any >= 2;
 a instanceof b as unknown instanceof c;
-a in b as unknown in c;
-1 == 1 as unknown == 2;
-1 != 1 as unknown != 2;
-1 === 1 as unknown === 2;
-1 !== 1 as unknown !== 2;
-1 & 1 as unknown & 2;
-1 ^ 1 as unknown ^ 2;
-1 | 1 as unknown | 2;
-1 && 1 as unknown && 2;
-1 || 1 as unknown || 2;
-1 ?? 1 as unknown ?? 2;
+a in b as any in c;
+a == b as number == c;
+a != b as unknown != c;
+a === b as unknown === c;
+a !== b as unknown !== c;
+a ^ b as any ^ c;
+a && 1 as unknown && c;
+a && b as unknown || c;
+a || b as unknown || c;
+a || b as unknown && c;
+a ?? b as unknown ?? c;
 
 // Lower-precedence next operator should stay safe:
-a << a as unknown < a;
-a + a as unknown << a;
-a * a as unknown + a;
-a ** a as unknown * a;
-a <= a as unknown == a;
+a << a as any < a;
+a + a as any << a;
+a * a as any + a;
+a ** a as any * a;
+a <= a as any == a;
 
 // Equal-tier cross-operator cases should stay safe:
-(a * b) as unknown / c;
-(a % b) as unknown * c;
-(a + b) as unknown - c;
-(a << b) as unknown >> c;
-(a >>> b) as unknown << c;
-(a < b) as unknown >= c;
+(a * b) as any / c;
+(a % b) as any * c;
+(a + b) as any - c;
+(a << b) as any >> c;
+(a >>> b) as any << c;
+(a < b) as any >= c;
 (a <= b) as unknown instanceof c;
-(a in b) as unknown > c;
+(a in b) as any > c;
 (a == b) as unknown != c;
 (a === b) as unknown !== c;
 
-// Other safe targeted cases:
-1 * 1 as unknown + 2;
-1 ?? 1 as unknown || 2;
-1 * 1 as unknown /* comment */ + 2;
+// Comments do not interfere with safe erasure detection:
+1 * 1 as any /* comment */ + 2;

--- a/tests/fixture/cases/assertion-precedence-non-errors.ts
+++ b/tests/fixture/cases/assertion-precedence-non-errors.ts
@@ -1,0 +1,49 @@
+// Same-operator cases that should erase without error:
+1 * 1 as unknown * 2;
+1 / 1 as unknown / 2;
+1 % 1 as unknown % 2;
+1 + 1 as unknown + 2;
+1 - 1 as unknown - 2;
+1 << 1 as unknown << 2;
+1 >> 1 as unknown >> 2;
+1 >>> 1 as unknown >>> 2;
+1 < 1 as unknown < 2;
+1 <= 1 as unknown <= 2;
+1 > 1 as unknown > 2;
+1 >= 1 as unknown >= 2;
+a instanceof b as unknown instanceof c;
+a in b as unknown in c;
+1 == 1 as unknown == 2;
+1 != 1 as unknown != 2;
+1 === 1 as unknown === 2;
+1 !== 1 as unknown !== 2;
+1 & 1 as unknown & 2;
+1 ^ 1 as unknown ^ 2;
+1 | 1 as unknown | 2;
+1 && 1 as unknown && 2;
+1 || 1 as unknown || 2;
+1 ?? 1 as unknown ?? 2;
+
+// Lower-precedence next operator should stay safe:
+a << a as unknown < a;
+a + a as unknown << a;
+a * a as unknown + a;
+a ** a as unknown * a;
+a <= a as unknown == a;
+
+// Equal-tier cross-operator cases should stay safe:
+(a * b) as unknown / c;
+(a % b) as unknown * c;
+(a + b) as unknown - c;
+(a << b) as unknown >> c;
+(a >>> b) as unknown << c;
+(a < b) as unknown >= c;
+(a <= b) as unknown instanceof c;
+(a in b) as unknown > c;
+(a == b) as unknown != c;
+(a === b) as unknown !== c;
+
+// Other safe targeted cases:
+1 * 1 as unknown + 2;
+1 ?? 1 as unknown || 2;
+1 * 1 as unknown /* comment */ + 2;

--- a/tests/fixture/output/assertion-precedence-non-errors.js
+++ b/tests/fixture/output/assertion-precedence-non-errors.js
@@ -1,49 +1,56 @@
+let a    , b    , c    ;
+             
+
+// Operator is a TypeScript type operator
+a & b           ;
+//    ^^^^^^^^^^
+a | b               ;
+//    ^^^^^^^^^^^^^^
+
 // Same-operator cases that should erase without error:
-1 * 1            * 2;
-1 / 1            / 2;
-1 % 1            % 2;
-1 + 1            + 2;
-1 - 1            - 2;
-1 << 1            << 2;
-1 >> 1            >> 2;
-1 >>> 1            >>> 2;
-1 < 1            < 2;
-1 <= 1            <= 2;
-1 > 1            > 2;
-1 >= 1            >= 2;
+1 * 1           * 2;
+1 / 1           / 2;
+1 % 1           % 2;
+1 + 1           + 2;
+1 - 1           - 2;
+1 << 1           << 2;
+1 >> 1           >> 2;
+1 >>> 1           >>> 2;
+1 < 1        < 2;
+1 <= 1        <= 2;
+1 > 1        > 2;
+1 >= 1        >= 2;
 a instanceof b            instanceof c;
-a in b            in c;
-1 == 1            == 2;
-1 != 1            != 2;
-1 === 1            === 2;
-1 !== 1            !== 2;
-1 & 1               ;
-1 ^ 1            ^ 2;
-1 | 1               ;
-1 && 1            && 2;
-1 || 1            || 2;
-1 ?? 1            ?? 2;
+a in b        in c;
+a == b           == c;
+a != b            != c;
+a === b            === c;
+a !== b            !== c;
+a ^ b        ^ c;
+a && 1            && c;
+a && b            || c;
+a || b            || c;
+a || b            && c;
+a ?? b            ?? c;
 
 // Lower-precedence next operator should stay safe:
-a << a            < a;
-a + a            << a;
-a * a            + a;
-a ** a            * a;
-a <= a            == a;
+a << a        < a;
+a + a        << a;
+a * a        + a;
+a ** a        * a;
+a <= a        == a;
 
 // Equal-tier cross-operator cases should stay safe:
-(a * b)            / c;
-(a % b)            * c;
-(a + b)            - c;
-(a << b)            >> c;
-(a >>> b)            << c;
-(a < b)            >= c;
+(a * b)        / c;
+(a % b)        * c;
+(a + b)        - c;
+(a << b)        >> c;
+(a >>> b)        << c;
+(a < b)        >= c;
 (a <= b)            instanceof c;
-(a in b)            > c;
+(a in b)        > c;
 (a == b)            != c;
 (a === b)            !== c;
 
-// Other safe targeted cases:
-1 * 1            + 2;
-1 ?? 1            || 2;
-1 * 1            /* comment */ + 2;
+// Comments do not interfere with safe erasure detection:
+1 * 1        /* comment */ + 2;

--- a/tests/fixture/output/assertion-precedence-non-errors.js
+++ b/tests/fixture/output/assertion-precedence-non-errors.js
@@ -1,0 +1,49 @@
+// Same-operator cases that should erase without error:
+1 * 1            * 2;
+1 / 1            / 2;
+1 % 1            % 2;
+1 + 1            + 2;
+1 - 1            - 2;
+1 << 1            << 2;
+1 >> 1            >> 2;
+1 >>> 1            >>> 2;
+1 < 1            < 2;
+1 <= 1            <= 2;
+1 > 1            > 2;
+1 >= 1            >= 2;
+a instanceof b            instanceof c;
+a in b            in c;
+1 == 1            == 2;
+1 != 1            != 2;
+1 === 1            === 2;
+1 !== 1            !== 2;
+1 & 1               ;
+1 ^ 1            ^ 2;
+1 | 1               ;
+1 && 1            && 2;
+1 || 1            || 2;
+1 ?? 1            ?? 2;
+
+// Lower-precedence next operator should stay safe:
+a << a            < a;
+a + a            << a;
+a * a            + a;
+a ** a            * a;
+a <= a            == a;
+
+// Equal-tier cross-operator cases should stay safe:
+(a * b)            / c;
+(a % b)            * c;
+(a + b)            - c;
+(a << b)            >> c;
+(a >>> b)            << c;
+(a < b)            >= c;
+(a <= b)            instanceof c;
+(a in b)            > c;
+(a == b)            != c;
+(a === b)            !== c;
+
+// Other safe targeted cases:
+1 * 1            + 2;
+1 ?? 1            || 2;
+1 * 1            /* comment */ + 2;


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #62*

**Describe your changes**
This PR adds new logic to emit an error when a type assertion can not be safely erased.

**Testing performed**
New test fixtures for both good and bad cases have been added.

**Additional context**
It would be simpler to not take the operator precedence into account and to always error instead, forcing the author to always use explicit parenthesis when mixing type assertion operators within binary expressions. This felt too restrictive and adding operator precedence checks is not too complex.