### PR TITLE
Add support for  Module.registerHooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,14 @@ jobs:
     ci:
         name: Test + Lint + Check
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [20, 22, 24]
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: ${{ matrix.node-version }}
             - run: npm ci
             - run: npm run check
             - run: npm run format:check

--- a/loader/hooks.js
+++ b/loader/hooks.js
@@ -8,17 +8,32 @@ const FALLBACK_EXTENSIONS = [
     [".mjs", ".mts"],
 ];
 
+function fallbackSpecifier(err) {
+    const url = err?.url;
+    if (typeof url !== "string") return null;
+    for (const [fromExtension, toExtension] of FALLBACK_EXTENSIONS) {
+        if (url.endsWith(fromExtension)) {
+            return url.slice(0, -fromExtension.length) + toExtension;
+        }
+    }
+    return null;
+}
+
+function transformLoadResult(sourceText, url) {
+    return {
+        format: "module",
+        shortCircuit: true,
+        source: tsBlankSpace(sourceText) + "\n//# sourceURL=" + url,
+    };
+}
+
 export async function resolve(specifier, context, nextResolve) {
     try {
         return await nextResolve(specifier, context);
     } catch (err) {
-        const url = err?.url;
-        if (typeof url === "string") {
-            for (const [fromExtension, toExtension] of FALLBACK_EXTENSIONS) {
-                if (url.endsWith(fromExtension)) {
-                    return nextResolve(url.slice(0, -fromExtension.length) + toExtension, context);
-                }
-            }
+        const fallback = fallbackSpecifier(err);
+        if (fallback !== null) {
+            return nextResolve(fallback, context);
         }
         throw err;
     }
@@ -29,13 +44,27 @@ export async function load(url, context, nextLoad) {
         return nextLoad(url, context);
     }
 
-    const format = "module";
-    const result = await nextLoad(url, { ...context, format });
-    const transformedSource = tsBlankSpace(result.source.toString());
+    const result = await nextLoad(url, { ...context, format: "module" });
+    return transformLoadResult(result.source.toString(), url);
+}
 
-    return {
-        format,
-        shortCircuit: true,
-        source: transformedSource + "\n//# sourceURL=" + url,
-    };
+export function resolveSync(specifier, context, nextResolve) {
+    try {
+        return nextResolve(specifier, context);
+    } catch (err) {
+        const fallback = fallbackSpecifier(err);
+        if (fallback !== null) {
+            return nextResolve(fallback, context);
+        }
+        throw err;
+    }
+}
+
+export function loadSync(url, context, nextLoad) {
+    if (!TS_EXTENSIONS.some((extension) => url.endsWith(extension))) {
+        return nextLoad(url, context);
+    }
+
+    const result = nextLoad(url, { ...context, format: "module" });
+    return transformLoadResult(result.source.toString(), url);
 }

--- a/loader/register.js
+++ b/loader/register.js
@@ -1,3 +1,12 @@
-import { register } from "node:module";
+import * as Module from "node:module";
+import { createRequire } from "node:module";
 
-register("./hooks.js", import.meta.url);
+if (typeof Module.registerHooks === "function") {
+    const require = createRequire(import.meta.url);
+    const { resolveSync, loadSync } = require("./hooks.js");
+
+    Module.registerHooks({ resolve: resolveSync, load: loadSync });
+} else {
+    // Fallback to worker thread for older Node.js
+    Module.register("./hooks.js", import.meta.url);
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ts-blank-space",
     "description": "A small, fast, pure JavaScript type-stripper that uses the official TypeScript parser.",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "license": "Apache-2.0",
     "homepage": "https://bloomberg.github.io/ts-blank-space",
     "contributors": [


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #64*

**Describe your changes**
This patch makes ts-blank-space use `Module.registerHooks()` in place of `Module.register()` for newer node versions where `Module.registerHooks()` is available.
This PR is a part of our effort to reduce dependency on `Module.register()`(more details [here](https://nodejs.org/api/module.html#moduleregisterspecifier-parenturl-options)) 

**Testing performed**
Ran tests locally using `npm test`.

**Additional context**
Add any other context about your contribution here.
