### PR TITLE
test: add test cases from TypeScript issue 63527

### DIFF
--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -355,3 +355,23 @@ it("errors on prefix type assertion as arrow body within binary expressions", ()
     assert.equal(onError.mock.callCount(), 1);
     assert.equal(jsOutput, `(()=><any>{p:null}.p ?? 1);`);
 });
+
+// (negative) Test cases from https://github.com/microsoft/TypeScript/issues/63533
+it("error with the test cases from TypeScript issue 63533", () => {
+    const cases = [
+        `export const x03 = 1 + 1 as number * 2;`,
+        `export const x04 = 1 + 1 as any as number * 2;`,
+        `export const x23 = 1 >> 1 as number + 2;`,
+        `export const x24 = 1 >> 1 as any as number + 2;`,
+        `export const y03 = 1 + 1 satisfies number * 2;`,
+        `export const y04 = 1 + 1 satisfies any satisfies number * 2;`,
+        `export const y23 = 1 >> 1 satisfies number + 2;`,
+        `export const y24 = 1 >> 1 satisfies any satisfies number + 2;`,
+    ];
+    for (const tsInput of cases) {
+        const onError = mock.fn();
+        const jsOutput = tsBlankSpace(tsInput, onError);
+        assert.equal(onError.mock.callCount(), 1);
+        assert.equal(jsOutput, tsInput);
+    }
+});

--- a/tests/fixture/cases/assertion-precedence-non-errors.ts
+++ b/tests/fixture/cases/assertion-precedence-non-errors.ts
@@ -54,3 +54,57 @@ a <= a as any == a;
 
 // Comments do not interfere with safe erasure detection:
 1 * 1 as any /* comment */ + 2;
+
+// (Positive) Test cases from https://github.com/microsoft/TypeScript/issues/63527
+
+export const x01 = 1 as number * 2;
+export const x02 = 1 as any as number * 2;
+
+export const x05 = 1 as number + 1 * 2;
+export const x06 = 1 as any as number + 1 * 2;
+
+export const x07 = 1 * 1 as number + 2;
+export const x08 = 1 * 1 as any as number + 2;
+export const x09 = 1 as number * 1 + 2;
+export const x10 = 1 as any as number * 1 + 2;
+
+export const x11 = (1 + 1 as number) * 2;
+export const x12 = (1 + 1 as any as number) * 2;
+export const x13 = (1 as number + 1) * 2;
+export const x14 = (1 as any as number + 1) * 2;
+
+export const x15 = 1 + 1 as number === 2;
+export const x16 = 1 + 1 as any as number === 2;
+export const x17 = 1 + 1 as number > 2;
+export const x18 = 1 + 1 as any as number > 2;
+export const x19 = 1 + 1 as number >= 2;
+export const x20 = 1 + 1 as any as number >= 2;
+
+export const x21 = 1 + 1 as number >> 2;
+export const x22 = 1 + 1 as any as number >> 2;
+
+export const y01 = 1 satisfies number * 2;
+export const y02 = 1 satisfies any satisfies number * 2;
+
+export const y05 = 1 satisfies number + 1 * 2;
+export const y06 = 1 satisfies any satisfies number + 1 * 2;
+
+export const y07 = 1 * 1 satisfies number + 2;
+export const y08 = 1 * 1 satisfies any satisfies number + 2;
+export const y09 = 1 satisfies number * 1 + 2;
+export const y10 = 1 satisfies any satisfies number * 1 + 2;
+
+export const y11 = (1 + 1 satisfies number) * 2;
+export const y12 = (1 + 1 satisfies any satisfies number) * 2;
+export const y13 = (1 satisfies number + 1) * 2;
+export const y14 = (1 satisfies any satisfies number + 1) * 2;
+
+export const y15 = 1 + 1 satisfies number === 2;
+export const y16 = 1 + 1 satisfies any satisfies number === 2;
+export const y17 = 1 + 1 satisfies number > 2;
+export const y18 = 1 + 1 satisfies any satisfies number > 2;
+export const y19 = 1 + 1 satisfies number >= 2;
+export const y20 = 1 + 1 satisfies any satisfies number >= 2;
+
+export const y21 = 1 + 1 satisfies number >> 2;
+export const y22 = 1 + 1 satisfies any satisfies number >> 2;

--- a/tests/fixture/output/assertion-precedence-non-errors.js
+++ b/tests/fixture/output/assertion-precedence-non-errors.js
@@ -54,3 +54,57 @@ a <= a        == a;
 
 // Comments do not interfere with safe erasure detection:
 1 * 1        /* comment */ + 2;
+
+// (Positive) Test cases from https://github.com/microsoft/TypeScript/issues/63527
+
+export const x01 = 1           * 2;
+export const x02 = 1                  * 2;
+
+export const x05 = 1           + 1 * 2;
+export const x06 = 1                  + 1 * 2;
+
+export const x07 = 1 * 1           + 2;
+export const x08 = 1 * 1                  + 2;
+export const x09 = 1           * 1 + 2;
+export const x10 = 1                  * 1 + 2;
+
+export const x11 = (1 + 1          ) * 2;
+export const x12 = (1 + 1                 ) * 2;
+export const x13 = (1           + 1) * 2;
+export const x14 = (1                  + 1) * 2;
+
+export const x15 = 1 + 1           === 2;
+export const x16 = 1 + 1                  === 2;
+export const x17 = 1 + 1           > 2;
+export const x18 = 1 + 1                  > 2;
+export const x19 = 1 + 1           >= 2;
+export const x20 = 1 + 1                  >= 2;
+
+export const x21 = 1 + 1           >> 2;
+export const x22 = 1 + 1                  >> 2;
+
+export const y01 = 1                  * 2;
+export const y02 = 1                                * 2;
+
+export const y05 = 1                  + 1 * 2;
+export const y06 = 1                                + 1 * 2;
+
+export const y07 = 1 * 1                  + 2;
+export const y08 = 1 * 1                                + 2;
+export const y09 = 1                  * 1 + 2;
+export const y10 = 1                                * 1 + 2;
+
+export const y11 = (1 + 1                 ) * 2;
+export const y12 = (1 + 1                               ) * 2;
+export const y13 = (1                  + 1) * 2;
+export const y14 = (1                                + 1) * 2;
+
+export const y15 = 1 + 1                  === 2;
+export const y16 = 1 + 1                                === 2;
+export const y17 = 1 + 1                  > 2;
+export const y18 = 1 + 1                                > 2;
+export const y19 = 1 + 1                  >= 2;
+export const y20 = 1 + 1                                >= 2;
+
+export const y21 = 1 + 1                  >> 2;
+export const y22 = 1 + 1                                >> 2;


### PR DESCRIPTION
This adds the same test cases as used in https://github.com/microsoft/typescript-go/pull/4192.

We already have test coverage for this but copying the cases verbatim makes it trivial to confirm we have the same coverage and semantics.